### PR TITLE
Fix uniform buffer unmapping

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -1081,7 +1081,6 @@ void Renderer::updateUniformBuffer(float deltaTime) {
     ubo_.proj[1][1] *= 1;
 
     memcpy(uniformBuffersData, &ubo_, sizeof(ubo_));
-    vkUnmapMemory(device_, uniformBufferMemory_);
 }
 
 void Renderer::initAliens() {
@@ -1690,6 +1689,10 @@ Renderer::~Renderer() {
         vkDestroyDescriptorPool(device_, mainDescriptorPool_, nullptr);
     if (uniformBuffer_ != VK_NULL_HANDLE)
         vkDestroyBuffer(device_, uniformBuffer_, nullptr);
+    if (uniformBuffersData != nullptr) {
+        vkUnmapMemory(device_, uniformBufferMemory_);
+        uniformBuffersData = nullptr;
+    }
     if (uniformBufferMemory_ != VK_NULL_HANDLE)
         vkFreeMemory(device_, uniformBufferMemory_, nullptr);
 

--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -154,7 +154,7 @@ private:
     VkBuffer alienVertexBuffer_{VK_NULL_HANDLE};
     VkDeviceMemory alienVertexBufferMemory_{VK_NULL_HANDLE};
 
-    void* uniformBuffersData;
+    void* uniformBuffersData{nullptr};
 
     VkImage overlayImage_{VK_NULL_HANDLE};
     VkDeviceMemory overlayImageDeviceMemory_{VK_NULL_HANDLE};


### PR DESCRIPTION
## Summary
- keep uniform buffer mapped for frame updates
- unmap uniform buffer memory when tearing down Renderer

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684030c66f3c83209c7a396d4d5e4f82