### PR TITLE
Fix uniform buffer mapping

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -1081,7 +1081,6 @@ void Renderer::updateUniformBuffer(float deltaTime) {
     ubo_.proj[1][1] *= 1;
 
     memcpy(uniformBuffersData, &ubo_, sizeof(ubo_));
-    vkUnmapMemory(device_, uniformBufferMemory_);
 }
 
 void Renderer::initAliens() {
@@ -1690,8 +1689,11 @@ Renderer::~Renderer() {
         vkDestroyDescriptorPool(device_, mainDescriptorPool_, nullptr);
     if (uniformBuffer_ != VK_NULL_HANDLE)
         vkDestroyBuffer(device_, uniformBuffer_, nullptr);
-    if (uniformBufferMemory_ != VK_NULL_HANDLE)
+    if (uniformBufferMemory_ != VK_NULL_HANDLE) {
+        if (uniformBuffersData)
+            vkUnmapMemory(device_, uniformBufferMemory_);
         vkFreeMemory(device_, uniformBufferMemory_, nullptr);
+    }
 
     if (vertexBuffer_ != VK_NULL_HANDLE) {
         vkDestroyBuffer(device_, vertexBuffer_, nullptr);

--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -154,7 +154,7 @@ private:
     VkBuffer alienVertexBuffer_{VK_NULL_HANDLE};
     VkDeviceMemory alienVertexBufferMemory_{VK_NULL_HANDLE};
 
-    void* uniformBuffersData;
+    void* uniformBuffersData{nullptr};
 
     VkImage overlayImage_{VK_NULL_HANDLE};
     VkDeviceMemory overlayImageDeviceMemory_{VK_NULL_HANDLE};


### PR DESCRIPTION
## Summary
- avoid unmapping uniform buffer every frame
- unmap the buffer on shutdown
- initialize uniformBuffersData pointer

## Testing
- `./gradlew build` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6840099d183c83209028c85c2a8791f8