### PR TITLE
Fix particle system data and rendering

### DIFF
--- a/app/src/main/cpp/ParticleSystem.cpp
+++ b/app/src/main/cpp/ParticleSystem.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ParticleSystem.h"
+#include <cmath>
 
 void ParticleSystem::spawn(const glm::vec3 &pos, int count) {
 
@@ -12,9 +13,12 @@ void ParticleSystem::spawn(const glm::vec3 &pos, int count) {
         float speed = 0.15f + ((float)rand() / RAND_MAX) * 0.15f;
         p.position = pos;
         p.velocity = glm::vec3(cos(angle), sin(angle),0.0f) * speed;
+        p.acceleration = glm::vec3(0.0f);
         p.life = p.maxLife = 0.5f + ((float)rand() / RAND_MAX) * 0.3f;
         p.color = glm::vec4(1, 1, 0, 1); // yellowish, can randomize
         p.size = 0.025f + ((float)rand() / RAND_MAX) * 0.025f;
+        p.center = pos;
+        p.rotation = 0.0f;
         p.active = true;
     }
 }
@@ -29,13 +33,37 @@ void ParticleSystem::getActiveParticles(std::vector<ParticleInstance>& out) cons
 }
 
 
-void
-ParticleSystem::render(VkCommandBuffer cmd, VkPipelineLayout pipelineLayout, VkPipeline pipeline, ...) {
+void ParticleSystem::render(VkCommandBuffer cmd,
+                            VkPipelineLayout pipelineLayout,
+                            VkPipeline pipeline,
+                            VkBuffer vertexBuffer,
+                            VkBuffer indexBuffer,
+                            VkBuffer instanceBuffer,
+                            uint32_t activeCount) {
+    if (activeCount == 0) return;
 
+    VkDeviceSize offsets[] = {0, 0};
+    VkBuffer vertexBuffers[] = {vertexBuffer, instanceBuffer};
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    vkCmdBindVertexBuffers(cmd, 0, 2, vertexBuffers, offsets);
+    vkCmdBindIndexBuffer(cmd, indexBuffer, 0, VK_INDEX_TYPE_UINT16);
+    vkCmdDrawIndexed(cmd, 6, activeCount, 0, 0, 0);
 }
 
 ParticleSystem::ParticleSystem() {
-
+    for (auto &p : particles) {
+        p.position = glm::vec3(0.0f);
+        p.velocity = glm::vec3(0.0f);
+        p.acceleration = glm::vec3(0.0f);
+        p.life = 0.0f;
+        p.maxLife = 0.0f;
+        p.active = false;
+        p.center = glm::vec3(0.0f);
+        p.size = 0.0f;
+        p.rotation = 0.0f;
+        p.color = glm::vec4(0.0f);
+    }
 }
 
 ParticleSystem::~ParticleSystem() {
@@ -46,7 +74,9 @@ void ParticleSystem::update(float deltaTime) {
     for (int i = 0; i < MAX_PARTICLES; ++i) {
         ParticleInstance& p = particles[i];
         if (!p.active) continue;
+        p.velocity += p.acceleration * deltaTime;
         p.position += p.velocity * deltaTime;
+        p.center = p.position;
         p.life -= deltaTime;
         p.color.a = glm::clamp(p.life / p.maxLife, 0.0f, 1.0f); // Fade out
         if (p.life <= 0) p.active = false;

--- a/app/src/main/cpp/ParticleSystem.h
+++ b/app/src/main/cpp/ParticleSystem.h
@@ -40,7 +40,13 @@ public:
 
     void update(float deltaTime);
 
-    void render(VkCommandBuffer cmd, VkPipelineLayout pipelineLayout, VkPipeline pipeline, ...);
+    void render(VkCommandBuffer cmd,
+                VkPipelineLayout pipelineLayout,
+                VkPipeline pipeline,
+                VkBuffer vertexBuffer,
+                VkBuffer indexBuffer,
+                VkBuffer instanceBuffer,
+                uint32_t activeCount);
 
     void getActiveParticles(std::vector<ParticleInstance> &out) const;
 };

--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -143,7 +143,7 @@ private:
     VkDescriptorPool particlesDescriptorPool_{VK_NULL_HANDLE};
     VkDescriptorSetLayout particlesDescriptorSetLayout_{VK_NULL_HANDLE};
 
-    void recordCommandBuffer(uint32_t imageIndex);
+    void recordCommandBuffer(uint32_t imageIndex, uint32_t particleCount);
     void initVulkan();
     void updateBullet(float deltaTime);
     void updateAliens(float deltaTime);


### PR DESCRIPTION
## Summary
- initialize particle fields properly
- implement ParticleSystem::render
- copy instance data to the correct buffer
- allocate and destroy particle buffers correctly
- draw only active particles

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3213c0083209783fbfce98eed12