### PR TITLE
Fix star instancing depth

### DIFF
--- a/app/src/main/cpp/GameObjectData.h
+++ b/app/src/main/cpp/GameObjectData.h
@@ -115,6 +115,15 @@ static const Vertex particleVerts[4] = {
         {{-0.5f,0.5f, 1.0f},{0.0f,1.0f,0.0f},{0.0f, 1.0f}}
 };
 
+// Quad for background stars.  Z is 0 so stars remain within the clip space
+// when scaled and offset in the vertex shader.
+static const Vertex starVerts[4] = {
+        {{-0.5f,-0.5f, 0.0f},{1.0f,1.0f,0.0f},{0.0f, 0.0f}},
+        {{0.5f,-0.5f, 0.0f},{1.0f,1.0f,0.0f},{1.0f, 0.0f}},
+        {{0.5f,0.5f,  0.0f},{1.0f,0.5f,0.0f},{1.0f, 1.0f}},
+        {{-0.5f,0.5f, 0.0f},{0.0f,1.0f,0.0f},{0.0f, 1.0f}}
+};
+
 static const uint16_t particlesIndices[6] = {0, 1, 2, 2, 3, 0};
 
 // Relative to (0, 0); will offset per-bullet in the shader or CPU

--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -2083,12 +2083,12 @@ void Renderer::loadText() {
 }
 
 void Renderer::loadGameObjects() {
-    VkDeviceSize starBufferSize = sizeof(particleVerts);
+    VkDeviceSize starBufferSize = sizeof(starVerts);
     createBuffer(device_, physicalDevice_, starBufferSize,
                  VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
                  starVertsBuffer_, starVertsMemory_);
 
-    uploadDataBuffer(device_, (void *) particleVerts, starBufferSize, starVertsMemory_);
+    uploadDataBuffer(device_, (void *) starVerts, starBufferSize, starVertsMemory_);
 
     VkDeviceSize starIndexSize = sizeof(particlesIndices);
     createBuffer(device_, physicalDevice_, starIndexSize,


### PR DESCRIPTION
## Summary
- keep background stars within the clip space
- use dedicated vertices for star instances

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b8d5a3788320b8fcdc580560cb87