### PR TITLE
Fix double swapchain destruction

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -2457,7 +2457,6 @@ Renderer::~Renderer() {
     }
 
     vkDestroyCommandPool(device_, commandPool_, nullptr);
-    vkDestroySwapchainKHR(device_, swapchain_, nullptr);
 
     if (surface_ != VK_NULL_HANDLE) {
         vkDestroySurfaceKHR(instance_, surface_, nullptr);


### PR DESCRIPTION
## Summary
- remove the unconditional swapchain destroy in `Renderer::~Renderer`
- keep cleanup behind the existing null-check

## Testing
- `sh ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6af4eaf08320ab93c3d265d96e46