### PR TITLE
Embed score state in Renderer

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -2054,15 +2054,6 @@ void Renderer::updateAliens(float deltaTime) {
     }
 }
 
-int actualScore = 0;            // Game logic value
-float displayedScore_ = 0.0f;    // Smoothed UI value
-float scoreAnimSpeed_ = 400.0f;  // Units per second (tune for effect)
-std::string scoreText_;          // Current display string, e.g. "Score: 1234"
-
-float scoreScale_ = 0.002f;         // Current scale for the pop effect
-float scoreScaleTarget_ = 0.002f;   // Where we're scaling toward
-float scoreScaleSpeed_ = 6.0f;    // How quickly scale returns to normal
-float scorePopAmount_ = 0.0022f;    // How much to “pop” the score on change
 
 uint i = 0;
 

--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -2,6 +2,7 @@
 
 #include "FontManager.h"
 #include "ParticleSystem.h"
+#include <string>
 
 class Renderer {
 public:
@@ -116,6 +117,17 @@ private:
 
     VkBuffer scoreTextVertexBuffer_;
     VkDeviceMemory scoreTextVertexBufferMemory_;
+
+    // Score tracking and animation
+    int actualScore = 0;            // Game logic value
+    float displayedScore_ = 0.0f;   // Smoothed UI value
+    float scoreAnimSpeed_ = 400.0f; // Units per second (tune for effect)
+    std::string scoreText_;         // Current display string, e.g. "Score: 1234"
+
+    float scoreScale_ = 0.002f;        // Current scale for the pop effect
+    float scoreScaleTarget_ = 0.002f;  // Where we're scaling toward
+    float scoreScaleSpeed_ = 6.0f;     // How quickly scale returns to normal
+    float scorePopAmount_ = 0.0022f;   // How much to “pop” the score on change
 
     VkBuffer particlesVertexBuffer_{VK_NULL_HANDLE};
     VkDeviceMemory particlesVertexBufferMemory_{VK_NULL_HANDLE};


### PR DESCRIPTION
## Summary
- store score and animation values as Renderer members
- remove global score variables

## Testing
- `./gradlew tasks --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6b1749088320b2c90897d00bd09e