### PR TITLE
Fix projection matrix orientation

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -1404,7 +1404,8 @@ void Renderer::updateUniformBuffer(float deltaTime) {
     ubo_.proj = glm::perspective(glm::radians(45.0f),
                                  swapchainExtent_.width / (float) swapchainExtent_.height, 0.1f,
                                  10.0f);
-    ubo_.proj[1][1] *= 1;
+    // Flip the Y coordinate for Vulkan's coordinate system
+    ubo_.proj[1][1] *= -1;
 
     memcpy(uniformBuffersData, &ubo_, sizeof(ubo_));
 }


### PR DESCRIPTION
## Summary
- flip Y axis in updateUniformBuffer to handle Vulkan's coordinate system

## Testing
- `./gradlew assembleDebug --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6b653a4483208d7c6ef711a20e74