### PR TITLE
Fix power-up Y coordinate push constant

### DIFF
--- a/app/src/main/cpp/PowerUpManager.cpp
+++ b/app/src/main/cpp/PowerUpManager.cpp
@@ -37,8 +37,8 @@ void PowerUpManager::recordCommandBuffer(VkCommandBuffer cmd, VkPipelineLayout p
                                          glm::vec2 shakeOffset) {
 
     for (auto powerUp:powerUps_) {
-        MainPushConstants pushConstants ={};
-        pushConstants.pos = {powerUp.pos.x, powerUp.pos.y};
+        MainPushConstants pushConstants = {};
+        pushConstants.pos = {powerUp.pos.x, -powerUp.pos.y};
         pushConstants.shakeOffset = shakeOffset;
 
         VkDeviceSize offsets[] = {0};


### PR DESCRIPTION
## Summary
- ensure power-ups match bullet and alien Y orientation

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686462eb4a908320863434bc9049ae79