### PR TITLE
Fix alien bullet spawn logic

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -2034,11 +2034,12 @@ void Renderer::spawnBullet(BulletType bulletType, glm::vec2 spawnPos) {
 //                 lastFireTime = 0.0f;
             }
 
-            if (BulletType::Alien == bulletType) {
+            if (!bullets_[i].active && bulletType == BulletType::Alien) {
                 bullets_[i].x = spawnPos.x;
                 bullets_[i].y = spawnPos.y - 0.04f;
                 bullets_[i].active = true;
                 bullets_[i].bulletType = bulletType;
+                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- correct alien bullet spawning logic so bullets are only created on an available slot

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876329aa17883208027d13c88b664a8