### PR TITLE
Ensure bullets deactivate once leaving screen

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -2053,13 +2053,15 @@ void Renderer::updateShipBuffer() const {
 void Renderer::updateBullet() {
     for (int i = 0; i < MAX_BULLETS; ++i) {
         if (bullets_[i].active) {
-            if (bullets_[i].bulletType == BulletType::Ship) bullets_[i].y -= bulletMoveSpeed_ *
-                                                                             Time::deltaTime; // Move up
-            if (bullets_[i].bulletType == BulletType::Alien) bullets_[i].y += 0.5f *
-                                                                              Time::deltaTime; // Move down
+            if (bullets_[i].bulletType == BulletType::Ship)
+                bullets_[i].y -= bulletMoveSpeed_ * Time::deltaTime; // Move up
+            if (bullets_[i].bulletType == BulletType::Alien)
+                bullets_[i].y += 0.5f * Time::deltaTime;             // Move down
 
-            if (bullets_[i].y < -1.0f)
+            if ((bullets_[i].bulletType == BulletType::Ship && bullets_[i].y < -1.0f) ||
+                (bullets_[i].bulletType == BulletType::Alien && bullets_[i].y > 1.0f)) {
                 bullets_[i].active = false; // Off screen
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- deactivate ship and alien bullets when they move beyond the visible range

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687632a477b0832081433511590b49af