### PR TITLE
Initialize powerUpTextCDOffset

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -149,7 +149,7 @@ private:
     VkBuffer fontVertexBuffer_;
     VkDeviceMemory fontBufferMemory_;
     VkDeviceSize scoreOffset_ = 0;
-    VkDeviceSize powerUpTextCDOffset;
+    VkDeviceSize powerUpTextCDOffset = 0;
 
     // Score tracking and animation
     int actualScore = 0;            // Game logic value


### PR DESCRIPTION
## Summary
- initialize `powerUpTextCDOffset` to avoid undefined values

## Testing
- `./gradlew tasks --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6d77e74c8320992bc89b014fef53