### PR TITLE
Fix elapsed time handling in power-up manager

### DIFF
--- a/app/src/main/cpp/PowerUpManager.cpp
+++ b/app/src/main/cpp/PowerUpManager.cpp
@@ -47,19 +47,17 @@ PowerUpManager::PowerUpManager() {
 
 }
 
-float elapsedTime = 0.0f;
-
 void PowerUpManager::recordCommandBuffer(VkCommandBuffer cmd, VkPipelineLayout pipelineLayout,
                                          VkPipeline pipeline,
                                          glm::vec2 shakeOffset,
                                          VkDescriptorSet descriptorSet) {
 
     for (auto powerUp: powerUps_) {
-        elapsedTime += Time::deltaTime;
+        elapsedTime_ += Time::deltaTime;
         MainPushConstants pushConstants = {};
         pushConstants.pos = {powerUp.pos.x, -powerUp.pos.y};
         pushConstants.shakeOffset = shakeOffset;
-        pushConstants.time = elapsedTime;
+        pushConstants.time = elapsedTime_;
         pushConstants.canPulse = 1;
         if (powerUp.type == PowerUpType::DoubleShot) pushConstants.texturePos = 3;
         if (powerUp.type == PowerUpType::Shield) pushConstants.texturePos = 4;

--- a/app/src/main/cpp/PowerUpManager.h
+++ b/app/src/main/cpp/PowerUpManager.h
@@ -35,6 +35,7 @@ private:
 
     VkDevice device_;
     const std::shared_ptr<Util> util_;
+    float elapsedTime_ = 0.0f;
 public:
     std::unordered_map<GameText,PowerUpIndicator> collectedPowerUps;
     bool doubleShotActive = false;


### PR DESCRIPTION
## Summary
- store elapsed time as member variable in `PowerUpManager`
- remove obsolete global `elapsedTime`
- update rendering logic to use the new member

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6ef229108320b1d58491c78d5f8f