### PR TITLE
Refactor simulation scheduler into ordered systems

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -27,8 +27,10 @@ add_library(SpaceInvaders3D SHARED
         game/AlienManager.cpp
         game/GameWorldManager.cpp
         ecs/systems/AlienSpawnSystem.cpp
+        ecs/systems/BulletSpawnSystem.cpp
         ecs/systems/CollisionSystem.cpp
         ecs/systems/FiringSystem.cpp
+        ecs/systems/ShipInputSystem.cpp
         ecs/worlds/PrefabLibrary.cpp
         input/FireCommand.cpp
         input/MoveShipCommand.cpp

--- a/app/src/main/cpp/ecs/components/GameplayComponents.h
+++ b/app/src/main/cpp/ecs/components/GameplayComponents.h
@@ -51,3 +51,12 @@ struct DirectionalMovement {
     float direction = 1.0f;
 };
 
+struct SpawnBulletRequest {
+    std::string prefab;
+    glm::vec2 position{};
+};
+
+struct SpawnRequests {
+    std::vector<SpawnBulletRequest> bullets{};
+};
+

--- a/app/src/main/cpp/ecs/systems/BulletSpawnSystem.cpp
+++ b/app/src/main/cpp/ecs/systems/BulletSpawnSystem.cpp
@@ -1,0 +1,33 @@
+#include "BulletSpawnSystem.h"
+
+#include "ecs/components/GameplayComponents.h"
+#include "game/GameWorldManager.h"
+
+namespace ecs {
+
+void BulletSpawnSystem::update(GameWorldManager &manager, bool isPlaying) const {
+    if (!isPlaying) {
+        return;
+    }
+
+    auto settingsId = manager.settingsEntity();
+    if (!settingsId.has_value()) {
+        return;
+    }
+
+    auto &world = manager.world();
+    auto &spawns = world.pool<SpawnRequests>();
+    auto *queue = spawns.tryGet(*settingsId);
+    if (!queue || queue->bullets.empty()) {
+        return;
+    }
+
+    for (const auto &spawn : queue->bullets) {
+        (void) manager.spawnBullet(spawn.prefab, spawn.position);
+    }
+
+    queue->bullets.clear();
+}
+
+} // namespace ecs
+

--- a/app/src/main/cpp/ecs/systems/BulletSpawnSystem.h
+++ b/app/src/main/cpp/ecs/systems/BulletSpawnSystem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class GameWorldManager;
+
+namespace ecs {
+
+class BulletSpawnSystem {
+public:
+    void update(GameWorldManager &manager, bool isPlaying) const;
+};
+
+} // namespace ecs
+

--- a/app/src/main/cpp/ecs/systems/FiringSystem.cpp
+++ b/app/src/main/cpp/ecs/systems/FiringSystem.cpp
@@ -40,7 +40,13 @@ void FiringSystem::update(GameWorldManager &manager, float deltaTime, bool isPla
     const uint32_t idx = Util::getRandomUint(0, static_cast<uint32_t>(aliveAliens.size() - 1));
     const Alien &alien = aliens.get(aliveAliens[idx]);
     const std::string bulletPrefab = settings ? settings->activeAlienBulletPrefab : std::string{"alien_primary"};
-    (void) manager.spawnBullet(bulletPrefab, {alien.x, -alien.y});
+
+    auto &spawns = world.pool<SpawnRequests>();
+    if (!spawns.has(*settingsId)) {
+        spawns.add(*settingsId, SpawnRequests{});
+    }
+
+    spawns.get(*settingsId).bullets.push_back(SpawnBulletRequest{bulletPrefab, {alien.x, -alien.y}});
 }
 
 } // namespace ecs

--- a/app/src/main/cpp/ecs/systems/ShipInputSystem.cpp
+++ b/app/src/main/cpp/ecs/systems/ShipInputSystem.cpp
@@ -1,0 +1,87 @@
+#include "ShipInputSystem.h"
+
+#include "ecs/components/CombatComponents.h"
+#include "ecs/components/GameplayComponents.h"
+#include "game/GameWorldManager.h"
+#include "PowerUpManager.h"
+
+namespace ecs {
+
+void ShipInputSystem::queueInput(const glm::vec2 &pos, bool wantsToFire) {
+    pendingShipPos_ = pos;
+    hasPendingInput_ = true;
+    wantsToFire_ = wantsToFire_ || wantsToFire;
+}
+
+void ShipInputSystem::applyPendingInput(GameWorldManager &manager) {
+    auto &world = manager.world();
+    auto shipId = manager.shipEntity();
+    if (!shipId.has_value()) {
+        return;
+    }
+
+    auto &ships = world.pool<Ship>();
+    if (!ships.has(*shipId) || !hasPendingInput_) {
+        return;
+    }
+
+    auto &ship = ships.get(*shipId);
+    ship.x = pendingShipPos_.x;
+    ship.y = pendingShipPos_.y;
+
+    hasPendingInput_ = false;
+}
+
+void ShipInputSystem::queueBulletRequests(GameWorldManager &manager, PowerUpManager &powerUps) {
+    auto settingsId = manager.settingsEntity();
+    if (!settingsId.has_value()) {
+        return;
+    }
+
+    auto &world = manager.world();
+    auto &spawns = world.pool<SpawnRequests>();
+    if (!spawns.has(*settingsId)) {
+        spawns.add(*settingsId, SpawnRequests{});
+    }
+
+    auto &queue = spawns.get(*settingsId);
+
+    const bool doubleShot = powerUps.doubleShotActive;
+    const glm::vec2 spawnPos{pendingShipPos_.x, pendingShipPos_.y};
+    if (doubleShot) {
+        queue.bullets.push_back(SpawnBulletRequest{dualBulletPrefab_, {spawnPos.x - 0.05f, spawnPos.y - 0.04f}});
+        queue.bullets.push_back(SpawnBulletRequest{dualBulletPrefab_, {spawnPos.x + 0.05f, spawnPos.y - 0.04f}});
+    } else {
+        queue.bullets.push_back(SpawnBulletRequest{shipBulletPrefab_, {spawnPos.x, spawnPos.y - 0.04f}});
+    }
+}
+
+void ShipInputSystem::update(GameWorldManager &manager, PowerUpManager &powerUps, float deltaTime, bool isPlaying) {
+    fireAccumulator_ += deltaTime;
+
+    if (!isPlaying) {
+        wantsToFire_ = false;
+        hasPendingInput_ = false;
+        return;
+    }
+
+    applyPendingInput(manager);
+
+    if (fireAccumulator_ < rateOfFire_ || !wantsToFire_) {
+        return;
+    }
+
+    queueBulletRequests(manager, powerUps);
+
+    fireAccumulator_ = 0.0f;
+    wantsToFire_ = false;
+}
+
+void ShipInputSystem::reset() {
+    fireAccumulator_ = rateOfFire_;
+    wantsToFire_ = false;
+    hasPendingInput_ = false;
+}
+
+} // namespace ecs
+

--- a/app/src/main/cpp/ecs/systems/ShipInputSystem.h
+++ b/app/src/main/cpp/ecs/systems/ShipInputSystem.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <glm/vec2.hpp>
+#include <string>
+
+class GameWorldManager;
+class PowerUpManager;
+
+namespace ecs {
+
+class ShipInputSystem {
+public:
+    void queueInput(const glm::vec2 &pos, bool wantsToFire);
+
+    void update(GameWorldManager &manager, PowerUpManager &powerUps, float deltaTime, bool isPlaying);
+
+    void reset();
+
+private:
+    void applyPendingInput(GameWorldManager &manager);
+    void queueBulletRequests(GameWorldManager &manager, PowerUpManager &powerUps);
+
+    glm::vec2 pendingShipPos_{0.0f};
+    bool hasPendingInput_{false};
+    bool wantsToFire_{false};
+
+    float rateOfFire_ = 0.2f;
+    float fireAccumulator_ = 0.0f;
+    std::string shipBulletPrefab_{"ship_primary"};
+    std::string dualBulletPrefab_{"ship_dual"};
+};
+
+} // namespace ecs
+

--- a/app/src/main/cpp/game/GameWorldManager.cpp
+++ b/app/src/main/cpp/game/GameWorldManager.cpp
@@ -161,6 +161,11 @@ void GameWorldManager::syncWaveSettings() {
     if (!cooldown.has(*settingsEntity_)) {
         cooldown.add(*settingsEntity_, FireCooldown{});
     }
+
+    auto &spawns = world_.pool<SpawnRequests>();
+    if (!spawns.has(*settingsEntity_)) {
+        spawns.add(*settingsEntity_, SpawnRequests{});
+    }
 }
 
 void GameWorldManager::initShip() {

--- a/app/src/main/cpp/game/SimulationScheduler.cpp
+++ b/app/src/main/cpp/game/SimulationScheduler.cpp
@@ -9,6 +9,10 @@
 
 SimulationScheduler::SimulationScheduler(Dependencies deps) : deps_(deps) {
     systems_.emplace_back([this](float dt, bool isPlaying) {
+        shipInputSystem_.update(deps_.world, deps_.powerUps, dt, isPlaying);
+    });
+
+    systems_.emplace_back([this](float dt, bool isPlaying) {
         alienSpawnSystem_.update(deps_.world, dt, isPlaying);
     });
 
@@ -22,106 +26,46 @@ SimulationScheduler::SimulationScheduler(Dependencies deps) : deps_(deps) {
         if (auto *movement = movementPool.tryGet(*settingsId)) {
             alienMovementSystem_.update(world, *movement, dt);
         }
+
+        std::vector<ecs::EntityId> toDestroy;
+        toDestroy.reserve(8);
+        bulletMovementSystem_.update(world, dt, toDestroy);
+        for (auto e : toDestroy) {
+            deps_.world.destroyEntity(e);
+        }
     });
 
     systems_.emplace_back([this](float dt, bool isPlaying) {
         firingSystem_.update(deps_.world, dt, isPlaying);
-    });
-
-    systems_.emplace_back([this](float dt, bool isPlaying) {
-        if (!isPlaying) return;
-        std::vector<ecs::EntityId> toDestroy;
-        toDestroy.reserve(8);
-        bulletMovementSystem_.update(deps_.world.world(), dt, toDestroy);
-        for (auto e : toDestroy) {
-            deps_.world.destroyEntity(e);
-        }
+        bulletSpawnSystem_.update(deps_.world, isPlaying);
     });
 
     systems_.emplace_back([this](float, bool isPlaying) {
         if (!isPlaying) return;
         collisionSystem_.update(deps_.world, deps_.particles, deps_.events, deps_.powerUps.shieldActive);
     });
+
+    systems_.emplace_back([this](float dt, bool isPlaying) {
+        if (!isPlaying) return;
+        if (deps_.mechanics) {
+            deps_.mechanics->update(dt);
+        }
+    });
 }
 
 void SimulationScheduler::setShipInput(float x, float y, bool fireBullet) {
-    pendingShipPos_ = {x, y - 0.12f};
-    hasPendingInput_ = true;
-    wantsToFire_ = wantsToFire_ || fireBullet;
-}
-
-void SimulationScheduler::applyShipInput() {
-    auto &world = deps_.world.world();
-    auto shipId = deps_.world.shipEntity();
-    if (!shipId.has_value()) {
-        return;
-    }
-    auto &ships = world.pool<Ship>();
-    if (!ships.has(*shipId)) {
-        return;
-    }
-    if (!hasPendingInput_) {
-        return;
-    }
-
-    auto &ship = ships.get(*shipId);
-    ship.x = pendingShipPos_.x;
-    ship.y = pendingShipPos_.y;
-
-    hasPendingInput_ = false;
-}
-
-void SimulationScheduler::trySpawnShipBullet() {
-    if (fireAccumulator_ < rateOfFire_) {
-        return;
-    }
-    if (!wantsToFire_) {
-        return;
-    }
-
-    auto &world = deps_.world.world();
-    const auto shipEntity = deps_.world.shipEntity();
-    if (!shipEntity.has_value()) {
-        return;
-    }
-
-    auto &ships = world.pool<Ship>();
-    if (!ships.has(*shipEntity)) {
-        return;
-    }
-
-    const bool doubleShot = deps_.powerUps.doubleShotActive;
-    const glm::vec2 spawnPos{pendingShipPos_.x, pendingShipPos_.y};
-    if (doubleShot) {
-        (void) deps_.world.spawnBullet(dualBulletPrefab_, {spawnPos.x - 0.05f, spawnPos.y - 0.04f});
-        (void) deps_.world.spawnBullet(dualBulletPrefab_, {spawnPos.x + 0.05f, spawnPos.y - 0.04f});
-    } else {
-        (void) deps_.world.spawnBullet(shipBulletPrefab_, {spawnPos.x, spawnPos.y - 0.04f});
-    }
-
-    fireAccumulator_ = 0.0f;
-    wantsToFire_ = false;
+    shipInputSystem_.queueInput({x, y - 0.12f}, fireBullet);
 }
 
 void SimulationScheduler::tick(float dt, bool isPlaying) {
-    fireAccumulator_ += dt;
-
     deps_.world.decayFlash(dt);
-
-    if (!isPlaying) {
-        wantsToFire_ = false;
-        hasPendingInput_ = false;
-        return;
-    }
-
-    applyShipInput();
-    trySpawnShipBullet();
 
     for (auto &system : systems_) {
         system(dt, isPlaying);
     }
-    if (deps_.mechanics) {
-        deps_.mechanics->update(dt);
+
+    if (!isPlaying) {
+        return;
     }
     deps_.powerUps.updatePowerUpData();
     const auto shipId = deps_.world.shipEntity();
@@ -143,8 +87,6 @@ void SimulationScheduler::resetWorld() {
         }
     }
 
-    fireAccumulator_ = rateOfFire_;
-    wantsToFire_ = false;
-    hasPendingInput_ = false;
+    shipInputSystem_.reset();
 }
 

--- a/app/src/main/cpp/game/SimulationScheduler.h
+++ b/app/src/main/cpp/game/SimulationScheduler.h
@@ -10,9 +10,11 @@
 #include "ecs/components/GameplayComponents.h"
 #include "ecs/systems/AlienMovementSystem.h"
 #include "ecs/systems/AlienSpawnSystem.h"
+#include "ecs/systems/BulletSpawnSystem.h"
 #include "ecs/systems/BulletMovementSystem.h"
 #include "ecs/systems/CollisionSystem.h"
 #include "ecs/systems/FiringSystem.h"
+#include "ecs/systems/ShipInputSystem.h"
 
 class EventBus;
 class GameMechanicsCoordinator;
@@ -37,21 +39,12 @@ public:
     void resetWorld();
 
 private:
-    void applyShipInput();
-    void trySpawnShipBullet();
-
     Dependencies deps_;
-    glm::vec2 pendingShipPos_{0.0f};
-    bool hasPendingInput_{false};
-    bool wantsToFire_{false};
 
-    float rateOfFire_ = 0.2f;
-    float fireAccumulator_ = 0.0f;
-    std::string shipBulletPrefab_{"ship_primary"};
-    std::string dualBulletPrefab_{"ship_dual"};
-
+    ecs::ShipInputSystem shipInputSystem_{};
     ecs::AlienSpawnSystem alienSpawnSystem_{};
     ecs::AlienMovementSystem alienMovementSystem_{};
+    ecs::BulletSpawnSystem bulletSpawnSystem_{};
     ecs::FiringSystem firingSystem_{};
     ecs::BulletMovementSystem bulletMovementSystem_{};
     ecs::CollisionSystem collisionSystem_{};


### PR DESCRIPTION
## Summary
- add ship input and bullet spawn systems to queue requests instead of spawning directly
- refactor simulation scheduler to run ordered input, movement, firing, collision, and mechanics systems
- route alien and ship bullet creation through shared spawn request components

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dcbfee2ac8320bcc13cb2326a0edb)